### PR TITLE
Use auto for textSize

### DIFF
--- a/cocos/platform/mac/CCDevice.mm
+++ b/cocos/platform/mac/CCDevice.mm
@@ -118,7 +118,6 @@ static bool _initWithString(const char * text, Device::TextAlign align, const ch
 				NSMutableString *lineBreak = [[[NSMutableString alloc] init] autorelease];
 				NSUInteger length = [string length];
 				NSRange range = NSMakeRange(0, 1);
-                CGSize textSize;
 				NSUInteger lastBreakLocation = 0;
                 NSUInteger insertCount = 0;
 				for (NSUInteger i = 0; i < length; i++) {
@@ -128,7 +127,7 @@ static bool _initWithString(const char * text, Device::TextAlign align, const ch
 					if ([@"!?.,-= " rangeOfString:character].location != NSNotFound) {
                         lastBreakLocation = i + insertCount;
                     }
-                    textSize = [lineBreak sizeWithAttributes:tokenAttributesDict];
+                    auto textSize = [lineBreak sizeWithAttributes:tokenAttributesDict];
                     if(textSize.height > info->height)
                         break;
 					if (textSize.width > info->width) {


### PR DESCRIPTION
`sizeWithAttributes` can return either `NSSize` or `CGSize`. Use `auto` to prevent any compilation errors.
